### PR TITLE
Fix exception when enabling widget-selection mode in Widget Inspector when popover is open

### DIFF
--- a/lib/src/popover_item.dart
+++ b/lib/src/popover_item.dart
@@ -134,6 +134,7 @@ class _PopoverItemState extends State<PopoverItem> {
   }
 
   void _configureRect() {
+    if (!widget.context.mounted) return;
     final offset = BuildContextExtension.getWidgetLocalToGlobal(widget.context);
     final bounds = BuildContextExtension.getWidgetBounds(widget.context);
 


### PR DESCRIPTION
Visual Studio Code's Widget Inspector causes 'PopoverItem' to throw an exception when trying to recalculate the bounds of the injected 'BuildContext', because the context has been unmounted possibly due to the popover being open and the currently active route. For whatever reason, the widget is mounted when 'didChangeDependencies' is called, but not in the post-frame callback that tries to use the deactivated context.

This pull request prevents the exception from being thrown when enabling widget selection mode in VSCode's Widget Inspector while the popover is open.

[*This is the issue that is fixed.*](https://github.com/minikin/popover/issues/63)

Here is a video of the exception before and after it's fixed.
https://user-images.githubusercontent.com/3419440/221905336-380560e0-774c-4274-84e7-4ad131d02995.mp4

_I will note that I cannot replicate the issue on the example app included with this library_.