### PR TITLE
fix: Use logical pixels for popover offset calculation

### DIFF
--- a/lib/src/utils/popover_utils.dart
+++ b/lib/src/utils/popover_utils.dart
@@ -33,9 +33,9 @@ abstract class PopoverUtils {
     }
   }
 
-  static final physicalSize =
+  static Size get physicalSize =>
       PlatformDispatcher.instance.views.first.physicalSize /
-          PlatformDispatcher.instance.views.first.devicePixelRatio;
+      PlatformDispatcher.instance.views.first.devicePixelRatio;
 }
 
 typedef PopoverTransitionBuilder = Widget Function(

--- a/lib/src/utils/popover_utils.dart
+++ b/lib/src/utils/popover_utils.dart
@@ -34,7 +34,8 @@ abstract class PopoverUtils {
   }
 
   static final physicalSize =
-      PlatformDispatcher.instance.views.first.physicalSize;
+      PlatformDispatcher.instance.views.first.physicalSize /
+          PlatformDispatcher.instance.views.first.devicePixelRatio;
 }
 
 typedef PopoverTransitionBuilder = Widget Function(


### PR DESCRIPTION
Fixed popover cut-off issue by adjusting `physicalSize` in `PopoverUtils` to account for `devicePixelRatio`. This way, on high-DPI screens, the popover uses logical pixels for offset calculation.

<table>
<tr>
 <td><strong><code>physicalSize</code></strong></td>
 <td><strong><code>physicalSize / devicePixelRatio</code></strong></td>
<tr>
 <td>
<img src="https://github.com/minikin/popover/assets/56719400/f6c98628-776e-4cff-9b40-f929400d4b63"></td>
 <td><img src="https://github.com/minikin/popover/assets/56719400/bdf764ed-8f6b-48ed-a1d7-26e09b08eff4"></td>
</table>

## Closes

- #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved physical size calculation in popovers by considering the device pixel ratio, enhancing display accuracy on various devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->